### PR TITLE
Add --implicit (and -i) option to make:rule

### DIFF
--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -28,6 +28,24 @@ class RuleMakeCommand extends GeneratorCommand
     protected $type = 'Rule';
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        return str_replace(
+            '{{ ruleType }}',
+            $this->option('implicit') ? 'ImplicitRule': 'Rule',
+            parent::buildClass($name)
+        );
+    }
+
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class RuleMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -40,7 +40,7 @@ class RuleMakeCommand extends GeneratorCommand
     {
         return str_replace(
             '{{ ruleType }}',
-            $this->option('implicit') ? 'ImplicitRule': 'Rule',
+            $this->option('implicit') ? 'ImplicitRule' : 'Rule',
             parent::buildClass($name)
         );
     }
@@ -69,7 +69,7 @@ class RuleMakeCommand extends GeneratorCommand
     {
         return $rootNamespace.'\Rules';
     }
-    
+
     /**
      * Get the console command options.
      *

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -44,7 +44,6 @@ class RuleMakeCommand extends GeneratorCommand
         );
     }
 
-
     /**
      * Get the stub file for the generator.
      *
@@ -68,5 +67,17 @@ class RuleMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Rules';
+    }
+    
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule instead.'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -2,9 +2,9 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\{{ $baseRule }};
 
-class {{ class }} implements Rule
+class {{ class }} implements {{ $baseRule }}
 {
     /**
      * Create a new rule instance.

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -2,9 +2,9 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Contracts\Validation\{{ $baseRule }};
+use Illuminate\Contracts\Validation\{{ ruleType }};
 
-class {{ class }} implements {{ $baseRule }}
+class {{ class }} implements {{ ruleType }}
 {
     /**
      * Create a new rule instance.


### PR DESCRIPTION
Pretty straightforward PR, does what's written on the tin.

I might be blind, but I don't find tests for the make:* commands. This addition is really simple anyway.
If I'm wrong, just point me to the file, and I'll oblige.

Cheers